### PR TITLE
Fix returning no path in OSX carbon path

### DIFF
--- a/source/standardpaths.d
+++ b/source/standardpaths.d
@@ -909,9 +909,15 @@ version(Windows) {
         {
             enum carbonPath = "CoreServices.framework/Versions/A/CoreServices\0";
 
+            // This one still work as of macOS 15.1, it was used in Dplug for a good while
+            enum carbonPath2 = "/System/Library/Frameworks/CoreServices.framework/CoreServices\0";
+
             import core.sys.posix.dlfcn;
 
             void* handle = dlopen(carbonPath.ptr, RTLD_NOW | RTLD_LOCAL);
+            if (!handle)
+                handle = dlopen(carbonPath2.ptr, RTLD_NOW | RTLD_LOCAL);
+
             if (handle) {
                 ptrFSFindFolder = cast(typeof(ptrFSFindFolder))dlsym(handle, "FSFindFolder");
                 ptrFSRefMakePath = cast(typeof(ptrFSRefMakePath))dlsym(handle, "FSRefMakePath");


### PR DESCRIPTION
Hello!

This PR updates `standardpaths` to be compatible with modern macOS.

Issue: returning no path. With the printdirs.d example, was seen on macOS 15.2 or 14.4

This fix the issue with Carbon libs not being loaded on recent macOS with the existing path.

That leads to no font being found by printed, and was reported in https://github.com/AuburnSounds/printed/issues/51 by @tremus

Tag would be appreciated :x